### PR TITLE
Possibility to set custom distribution algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Please [★ on GitHub](https://github.com/marvelapp/react-ab-test)!
     - [`emitter.getActiveVariant(experimentName)`](#emittergetactivevariantexperimentname)
     - [`emitter.calculateActiveVariant(experimentName [, userIdentifier, defaultVariantName])`](#emittercalculateactivevariantexperimentname--useridentifier-defaultvariantname)
     - [`emitter.getSortedVariants(experimentName)`](#emittergetsortedvariantsexperimentname)
-    - [`emitter.setCustomDistributionAlgorithm(experimentName)`](#emittersetcustomdistributionalgorithmexperimentname)
+    - [`emitter.setCustomDistributionAlgorithm(customAlgorithm)`](#emittersetcustomdistributionalgorithmcustomalgorithm)
   - [`Subscription`](#subscription)
     - [`subscription.remove()`](#subscriptionremove)
   - [`experimentDebugger`](#experimentdebugger)
@@ -633,7 +633,7 @@ Returns a sorted array of variant names associated with the experiment.
     * **Type:** `string`
     * **Example:** `"My Example"`
 
-#### `emitter.setCustomDistributionAlgorithm(experimentName)`
+#### `emitter.setCustomDistributionAlgorithm(customAlgorithm)`
 
 Sets a custom function to use for calculating variants overriding the default. This can be usefull
 in cases when variants are expected from 3rd parties or when variants need to be

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Please [★ on GitHub](https://github.com/marvelapp/react-ab-test)!
     - [`emitter.getActiveVariant(experimentName)`](#emittergetactivevariantexperimentname)
     - [`emitter.calculateActiveVariant(experimentName [, userIdentifier, defaultVariantName])`](#emittercalculateactivevariantexperimentname--useridentifier-defaultvariantname)
     - [`emitter.getSortedVariants(experimentName)`](#emittergetsortedvariantsexperimentname)
+    - [`emitter.setCustomDistributionAlgorithm(experimentName)`](#emittersetcustomdistributionalgorithmexperimentname)
   - [`Subscription`](#subscription)
     - [`subscription.remove()`](#subscriptionremove)
   - [`experimentDebugger`](#experimentdebugger)

--- a/README.md
+++ b/README.md
@@ -632,6 +632,27 @@ Returns a sorted array of variant names associated with the experiment.
     * **Type:** `string`
     * **Example:** `"My Example"`
 
+#### `emitter.setCustomDistributionAlgorithm(experimentName)`
+
+Sets a custom function to use for calculating variants overriding the default. This can be usefull
+in cases when variants are expected from 3rd parties or when variants need to be
+in sync with other clients using ab test but different distribution algorithm.
+
+- **Return Type:** No return value
+- **Parameters:**
+  - `customAlgorithm` - Function for calculating variant distribution.
+    - **Required**
+    - **Type:** `function`
+    - **Callback Arguments:**
+      - `experimentName` - Name of the experiment.
+        - **Required**
+        - **Type:** `string`
+      - `userIdentifier` - User's value which is used to calculate the variant
+        - **Required**
+        - **Type:** `string`
+      - `defaultVariantName` - Default variant passed from the experiment
+        - **Type:** `string`
+
 ### `Subscription`
 
 Returned by the emitter's add listener methods. More information available in the [facebook/emitter documentation.](https://github.com/facebook/emitter#api-concepts)

--- a/src/emitter.jsx
+++ b/src/emitter.jsx
@@ -7,6 +7,7 @@ let experimentWeights = {};
 let activeExperiments = {};
 let experimentsWithDefinedVariants = {};
 let playedExperiments = {};
+let customDistributionAlgorithm = undefined;
 
 const emitter = new EventEmitter();
 
@@ -53,6 +54,7 @@ PushtellEventEmitter.prototype._reset = function () {
   activeExperiments = {};
   experimentsWithDefinedVariants = {};
   playedExperiments = {};
+  customDistributionAlgorithm = undefined;
 };
 
 PushtellEventEmitter.prototype.rewind = function () {
@@ -144,6 +146,12 @@ PushtellEventEmitter.prototype.addWinListener = function (
   });
 };
 
+PushtellEventEmitter.prototype.setCustomDistributionAlgorithm = function (
+  customAlgorithm
+) {
+  customDistributionAlgorithm = customAlgorithm;
+};
+
 PushtellEventEmitter.prototype.defineVariants = function (
   experimentName,
   variantNames,
@@ -212,6 +220,14 @@ PushtellEventEmitter.prototype.calculateActiveVariant = function (
   userIdentifier,
   defaultVariantName
 ) {
+  if (customDistributionAlgorithm !== undefined) {
+    return customDistributionAlgorithm(
+      experimentName,
+      userIdentifier,
+      defaultVariantName
+    );
+  }
+
   const variant = calculateActiveVariant(
     experimentName,
     userIdentifier,

--- a/test/browser/emitter.test.jsx
+++ b/test/browser/emitter.test.jsx
@@ -320,4 +320,17 @@ describe('Emitter', () => {
     const activeVariant = emitter.calculateActiveVariant(experimentName);
     expect(activeVariant).toEqual(emitter.getActiveVariant(experimentName));
   });
+
+  it('should use custom distribution algorithm when set', () => {
+    const experimentName = UUID();
+    emitter.defineVariants(experimentName, ['A', 'B']);
+    emitter.setCustomDistributionAlgorithm((_experimentName, userIdentifier) =>
+      parseInt(userIdentifier) % 4 === 0 ? 'A' : 'B'
+    );
+    const variants = [...Array(6).keys()].map((userIdentifier) =>
+      emitter.calculateActiveVariant(experimentName, userIdentifier.toString())
+    );
+
+    expect(variants).toEqual(['A', 'B', 'B', 'B', 'A', 'B']);
+  });
 });


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
<h1>Table of Contents</h1>

- [Description](#description)
- [Motivation and Context](#motivation-and-context)
- [How Has This Been Tested?](#how-has-this-been-tested)
- [Screenshots (if appropriate):](#screenshots-if-appropriate)
- [Types of changes](#types-of-changes)
- [Checklist:](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!--- Thank you for your pull request! This is a community supported 
project initially released by https://github.com/wehriam for your use
and enjoyment. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
After defining experiments user can also set a custom distribution algorithm to be used instead of default one. Although the default one is very good there is sometimes need to use something different.

## Motivation and Context
We have couple of different clients running AB tests (React native, extension and webapp). Some of these are legacy and very hard to change. They are using in-house distribution algorithm. I want the variants to match on all clients so I need a way to override default used here with algorithm used on other clients.

## How Has This Been Tested?
This has only been tested with unit tests. In case client does not set a custom distribution algorithm the library will behave the same way it did before. It's a non-breaking change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
