### PR TITLE
feat: replaces noop store with memory store

### DIFF
--- a/src/store.jsx
+++ b/src/store.jsx
@@ -1,8 +1,13 @@
 let store;
 
-const noopStore = {
-  getItem: function () {},
-  setItem: function () {},
+const memoryStore = {
+  values: {},
+  getItem: function (key) {
+    this.values[key];
+  },
+  setItem: function (key, value) {
+    this.values[key] = value;
+  },
 };
 
 if (typeof window !== 'undefined' && 'localStorage' in window) {
@@ -10,16 +15,16 @@ if (typeof window !== 'undefined' && 'localStorage' in window) {
     let key = '__pushtell_react__';
     window.localStorage.setItem(key, key);
     if (window.localStorage.getItem(key) !== key) {
-      store = noopStore;
+      store = memoryStore;
     } else {
       window.localStorage.removeItem(key);
       store = window.localStorage;
     }
   } catch (e) {
-    store = noopStore;
+    store = memoryStore;
   }
 } else {
-  store = noopStore;
+  store = memoryStore;
 }
 
 export default store;

--- a/src/store.jsx
+++ b/src/store.jsx
@@ -3,7 +3,7 @@ let store;
 const memoryStore = {
   values: {},
   getItem: function (key) {
-    this.values[key];
+    return this.values[key];
   },
   setItem: function (key, value) {
     this.values[key] = value;

--- a/test/browser/store.test.jsx
+++ b/test/browser/store.test.jsx
@@ -1,0 +1,18 @@
+describe('Store', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('works with browser storage', () => {
+    const store = require('../../src/store').default;
+    store.setItem('foo', 'bar');
+    expect(store.getItem('foo')).toEqual('bar');
+  });
+
+  it('works without browser storage', () => {
+    delete window.localStorage;
+    const store = require('../../src/store').default;
+    store.setItem('foo', 'bar');
+    expect(store.getItem('foo')).toEqual('bar');
+  });
+});


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
<h1>Table of Contents</h1>

- [Description](#description)
- [Motivation and Context](#motivation-and-context)
- [How Has This Been Tested?](#how-has-this-been-tested)
- [Screenshots (if appropriate):](#screenshots-if-appropriate)
- [Types of changes](#types-of-changes)
- [Checklist:](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!--- Thank you for your pull request! This is a community supported 
project initially released by https://github.com/wehriam for your use
and enjoyment. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
This implements a basic memory store instead of noop.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When server-side rendering, having a noop store causes `useExperiment` calls to fail even if they were made after a `emitter.defineVariants` call.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've added tests to store.jsx to check if it could set and get items from it. The most important part is to delete `window.localStorage` and keep it working properly. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
